### PR TITLE
現場社内検査実施の画面イメージ作成

### DIFF
--- a/inspection/approve-request.html
+++ b/inspection/approve-request.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>承認画面</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>社内検査実施依頼の承認</h1>
+    </header>
+    <section class="approval-section">
+      <form>
+        <label for="approvalComment">承認内容:</label>
+        <textarea
+          id="approvalComment"
+          name="approvalComment"
+          rows="5"
+          placeholder="承認理由を記入してください"
+        ></textarea>
+        <button type="submit">承認</button>
+      </form>
+    </section>
+    <footer>
+      <a href="manager-dashboard.html">ダッシュボードに戻る</a>
+    </footer>
+  </body>
+</html>

--- a/inspection/check-status-inspection.html
+++ b/inspection/check-status-inspection.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>現場社内検査実施一覧</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>現場社内検査実施一覧</h1>
+    </header>
+    <section class="status-inspection-section">
+      <h2>承認状況一覧</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>点検場所</th>
+            <th>点検項目</th>
+            <th>承認状況</th>
+            <th>通知</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>第1倉庫</td>
+            <td>防火扉点検</td>
+            <td>承認済み</td>
+            <td>承認が完了しました</td>
+          </tr>
+          <tr>
+            <td>第2倉庫</td>
+            <td>安全通路点検</td>
+            <td>未承認</td>
+            <td>なし</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+    <footer>
+      <a href="user-dashboard.html">ダッシュボードに戻る</a>
+    </footer>
+  </body>
+</html>

--- a/inspection/index.html
+++ b/inspection/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ユーザー選択</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>現場社内検査システム</h1>
+    </header>
+    <section>
+        <h2>ユーザータイプを選択してください</h2>
+        <nav>
+            <ul>
+                <li><a href="user-dashboard.html">担当ユーザーとしてログイン</a></li>
+                <li><a href="manager-dashboard.html">管理者ユーザーとしてログイン</a></li>
+            </ul>
+        </nav>
+    </section>
+</body>
+</html>

--- a/inspection/manager-dashboard.html
+++ b/inspection/manager-dashboard.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>管理者ダッシュボード</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>管理者ダッシュボード</h1>
+    </header>
+    <nav>
+      <ul>
+        <li><a href="approve-request.html">社内検査実施依頼の承認</a></li>
+        <li><a href="inspection-list.html">点検場所・点検項目を確認</a></li>
+      </ul>
+    </nav>
+    <footer>
+      <a href="index.html">ログアウト</a>
+    </footer>
+  </body>
+</html>

--- a/inspection/send-request.html
+++ b/inspection/send-request.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>承認依頼送信</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>社内検査実施の承認依頼を送信</h1>
+    </header>
+    <section class="request-section">
+      <form>
+        <label for="inspectionPlace">点検場所:</label>
+        <input
+          type="text"
+          id="inspectionPlace"
+          name="inspectionPlace"
+          placeholder="例: 第1倉庫"
+        />
+
+        <label for="inspectionItem">点検項目:</label>
+        <input
+          type="text"
+          id="inspectionItem"
+          name="inspectionItem"
+          placeholder="例: 防火扉点検"
+        />
+
+        <button type="submit">承認依頼を送信</button>
+      </form>
+    </section>
+    <footer>
+      <a href="user-dashboard.html">ダッシュボードに戻る</a>
+    </footer>
+  </body>
+</html>

--- a/inspection/style.css
+++ b/inspection/style.css
@@ -1,0 +1,105 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f4f4f4;
+  padding: 20px;
+}
+
+header {
+  background-color: #4caf50;
+  color: white;
+  padding: 10px 0;
+  text-align: center;
+}
+
+h1,
+h2 {
+  margin-bottom: 20px;
+}
+
+nav ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+nav ul li {
+  margin-bottom: 10px;
+}
+
+nav ul li a {
+  color: #4caf50;
+  text-decoration: none;
+  font-size: 18px;
+}
+
+nav ul li a:hover {
+  text-decoration: underline;
+}
+
+section {
+  background-color: white;
+  padding: 20px;
+  margin-bottom: 20px;
+  border-radius: 5px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+}
+
+form label {
+  margin-bottom: 5px;
+}
+
+form input,
+form button,
+form textarea {
+  margin-bottom: 15px;
+  padding: 10px;
+  font-size: 16px;
+}
+
+button {
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #45a049;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+table,
+th,
+td {
+  border: 1px solid #ddd;
+}
+
+th,
+td {
+  padding: 12px;
+  text-align: left;
+}
+
+th {
+  background-color: #f2f2f2;
+}
+
+footer {
+  text-align: center;
+  margin-top: 20px;
+}

--- a/inspection/user-dashboard.html
+++ b/inspection/user-dashboard.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>担当ユーザーダッシュボード</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>担当ユーザーダッシュボード</h1>
+    </header>
+    <nav>
+      <ul>
+        <li><a href="send-request.html">社内検査実施の承認依頼を送信</a></li>
+        <li>
+          <a href="check-status-inspection.html">承認状況・点検項目を確認</a>
+        </li>
+      </ul>
+    </nav>
+    <footer>
+      <a href="index.html">ログアウト</a>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
以下のユーザーストーリーをもとに、ChatGPTで画面イメージを作成

◾︎担当ユーザー
現場社内検査実施の承認依頼を送信できる
通知で現場社内検査実施依頼を確認できる
現場社内検査実施以来の承認状況を一覧で確認できる
承認内容を記入し、現場社内検査実施依頼を承認できる。

◾︎管理者ユーザー
現場社内検査をする対象の点検場所・点検項目を一覧で確認できる
依頼内容（点検場所・点検項目、点検報告書）を一覧で確認できる
承認されたことを通知で確認できる